### PR TITLE
Bavix v11 suport added

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "eimkasp/filament-wallet",
+    "name": "tomatophp/filament-wallet",
     "type": "library",
     "description": "Account Balance / Wallets Manager For FilamentPHP and Filament Account Builder",
     "keywords": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "tomatophp/filament-wallet",
+    "name": "eimkasp/filament-wallet",
     "type": "library",
     "description": "Account Balance / Wallets Manager For FilamentPHP and Filament Account Builder",
     "keywords": [


### PR DESCRIPTION
After testing locally I can confirm that package is compatable with v11 and up for Bavix wallet package. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Expanded compatibility for the wallet package, allowing users to leverage both version 10.x and 11.x features.
- **Bug Fixes**
	- Improved stability and support by updating the wallet package dependency, enhancing overall application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->